### PR TITLE
Enhance and fix the prefs module for all the features we need (#39)

### DIFF
--- a/greenlight/harness/testcase.py
+++ b/greenlight/harness/testcase.py
@@ -24,3 +24,5 @@ class FirefoxTestCase(MarionetteTestCase, Puppeteer):
 
     def tearDown(self, *args, **kwargs):
         MarionetteTestCase.tearDown(self, *args, **kwargs)
+
+        self.prefs.restore_all_prefs()

--- a/greenlight/lib/__init__.py
+++ b/greenlight/lib/__init__.py
@@ -42,13 +42,13 @@ class Puppeteer(object):
         See the :class:`~api.keys.Keys` reference.
         """
 
-    @use_class_as_property('api.prefs.DefaultPrefBranch')
+    @use_class_as_property('api.prefs.Preferences')
     def prefs(self):
         """
         Provides an api for setting and inspecting preferences, as see in
         about:config.
 
-        See the :class:`~api.prefs.DefaultPrefBranch` reference.
+        See the :class:`~api.prefs.Preferences` reference.
         """
 
 

--- a/greenlight/lib/api/prefs.py
+++ b/greenlight/lib/api/prefs.py
@@ -2,109 +2,206 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from marionette.errors import MarionetteException
+
 from ..base import BaseLib
 
 
-class DefaultPrefBranch(BaseLib):
+class Preferences(BaseLib):
     archive = {}
 
-    @classmethod
-    def _cast(cls, value):
-        """
-        Interpolate a preference from a string.
+    def get_pref(self, pref_name, default_branch=False, interface=None):
+        """Retrieves the value of a preference.
 
-        - integers will get cast to integers
-        - true/false will get cast to True/False
-        - anything enclosed in single quotes will be treated as a string with
-          the ''s removed from both sides
-        """
+        To retrieve the value of a preference its name has to be specified. By
+        default it will be read from the `user` branch, and returns the current
+        value. If the default value is wanted instead, ensure to flag that by
+        passing `True` via default_branch.
 
-        if not isinstance(value, basestring):
-            return value  # no op
-        quote = "'"
-        if value == 'true':
-            return True
-        if value == 'false':
-            return False
-        try:
-            return int(value)
-        except ValueError:
-            pass
-        if value.startswith(quote) and value.endswith(quote):
-            value = value[1:-1]
-        return value
+        It is also possible to retrieve the value of complex preferences, which
+        do not represent an atomic type like `basestring`, `int`, or `boolean`.
+        Specify the interface of the represented XPCOM object via `interface`.
 
-    def get_pref(self, pref):
-        """
-        Retrive a preference.
+        :param pref_name: The preference name
+        :param default_branch: Optional, flag to use the default branch,
+         default to `False`
+        :param interface: Optional, interface of the complex preference,
+         default to `None`. Possible values are: `nsILocalFile`,
+         `nsISupportsString`, and `nsIPrefLocalizedString`
 
-        :param pref: The preference to inspect,e.g
-                     browser.tabs.remote.autostart
-        :returns: The value of the specified pref.
+        :returns: The preference value.
         """
+        assert pref_name is not None
+
+        # Bug 1118825 - None is causing an exception to be raised
+        interface = interface or ''
+
         with self.marionette.using_context('chrome'):
-            value = self.marionette.execute_script("""
-              let pref = arguments[0];
-              let prefBranch = Cc["@mozilla.org/preferences-service;1"]
-                              .getService(Ci.nsIPrefBranch);
-              let type = prefBranch.getPrefType(pref);
+            return self.marionette.execute_script("""
+              Cu.import("resource://gre/modules/Services.jsm");
+
+              let pref_name = arguments[0];
+              let default_branch = arguments[1];
+              let interface = arguments[2];
+
+              let prefBranch;
+              if (default_branch) {
+                prefBranch = Services.prefs.getDefaultBranch("");
+              }
+              else {
+                prefBranch = Services.prefs;
+              }
+
+              // If an interface has been set, handle it differently
+              if (interface != '') {
+                return prefBranch.getComplexValue(pref_name,
+                                                  Ci[interface]).data;
+              }
+
+              let type = prefBranch.getPrefType(pref_name);
 
               switch (type) {
                 case prefBranch.PREF_STRING:
-                  return prefBranch.getCharPref(pref);
+                  return prefBranch.getCharPref(pref_name);
                 case prefBranch.PREF_BOOL:
-                  return prefBranch.getBoolPref(pref);
+                  return prefBranch.getBoolPref(pref_name);
                 case prefBranch.PREF_INT:
-                  return prefBranch.getIntPref(pref);
+                  return prefBranch.getIntPref(pref_name);
                 case prefBranch.PREF_INVALID:
                   return null;
               }
-            """, script_args=[pref])
+            """, script_args=[pref_name, default_branch, interface])
 
-        return self._cast(value)
+    def reset_pref(self, pref_name):
+        """Resets a user set preference.
 
-    def set_pref(self, pref, value):
+        Every modification of a preference will turn its status into a user-set
+        preference. To restore the default value of the preference, call this
+        function once. Further calls have no effect as long as the value hasn't
+        changed again.
+
+        In case the preference is not present on the default branch, it will be
+        completely removed.
+
+        :param pref_name: The preference to reset
+
+        :returns: `True` if a user preference has been removed
         """
-        Sets the specified pref to value. Also archives the old value so that
-        the pref can be restored with `restore_pref`.
+        assert pref_name is not None
 
-        :param pref: The preference to set.
-        :param value: The value to set the preference to.
-        """
         with self.marionette.using_context('chrome'):
-            self.archive[pref] = self.get_pref(pref)
+            return self.marionette.execute_script("""
+              Cu.import("resource://gre/modules/Services.jsm");
+              let prefBranch = Services.prefs;
 
-            ret = self.marionette.execute_script("""
-              let pref = arguments[0];
+              let pref_name = arguments[0];
+
+              if (prefBranch.prefHasUserValue(pref_name)) {
+                prefBranch.clearUserPref(pref_name);
+                return true;
+              }
+              else {
+                return false;
+              }
+            """, script_args=[pref_name])
+
+    def restore_all_prefs(self):
+        """Restores all previously modified preferences to their former values.
+
+        Please see :func:`~Preferences.restore_pref` for details.
+        """
+        while len(self.archive):
+            self.restore_pref(self.archive.keys()[0])
+
+    def restore_pref(self, pref_name):
+        """Restores a previously set preference to its former value.
+
+        The first time a preference gets modified a backup of its value is
+        made. By calling this method, exactly this value will be restored,
+        whether how often the preference has been modified again afterward.
+
+        If the preference did not exist before and has been newly created, it
+        will be reset to its original value. Please see
+        :func:`~Preferences.reset_pref` for details.
+
+        :param pref_name: The preference to restore
+        """
+        assert pref_name is not None
+
+        try:
+            # in case it is a newly set preference, reset it. Otherwise restore
+            # its original value.
+            if self.archive[pref_name] is None:
+                self.reset_pref(pref_name)
+            else:
+                self.set_pref(pref_name, self.archive[pref_name])
+
+            del self.archive[pref_name]
+        except KeyError:
+            raise MarionetteException('Nothing to restore for preference "%s"',
+                                      pref_name)
+
+    def set_pref(self, pref_name, value):
+        """Sets a preference to a specified value.
+
+        To set the value of a preference its name has to be specified.
+
+        The first time a new value for a preference is set, its value will be
+        automatically archived. It allows to restore the original value by
+        calling :func:`~Preferences.restore_pref`.
+
+        :param pref_name: The preference to set
+        :param value: The value to set the preference to
+        """
+        assert pref_name is not None
+        assert value is not None
+
+        with self.marionette.using_context('chrome'):
+            # Backup original value only once
+            if pref_name not in self.archive:
+                self.archive[pref_name] = self.get_pref(pref_name)
+
+            retval = self.marionette.execute_script("""
+              Cu.import("resource://gre/modules/Services.jsm");
+              let prefBranch = Services.prefs;
+
+              let pref_name = arguments[0];
               let value = arguments[1];
-              let prefBranch = Cc["@mozilla.org/preferences-service;1"]
-                               .getService(Ci.nsIPrefBranch);
-              let type = prefBranch.getPrefType(pref);
+
+              let type = prefBranch.getPrefType(pref_name);
+
+              // If the pref does not exist yet, get the type from the value
+              if (type == prefBranch.PREF_INVALID) {
+                switch (typeof value) {
+                  case "boolean":
+                    type = prefBranch.PREF_BOOL;
+                    break;
+                  case "number":
+                    type = prefBranch.PREF_INT;
+                    break;
+                  case "string":
+                    type = prefBranch.PREF_STRING;
+                    break;
+                  default:
+                    type = prefBranch.PREF_INVALID;
+                }
+              }
 
               switch (type) {
                 case prefBranch.PREF_BOOL:
-                  prefBranch.setBoolPref(pref, value);
+                  prefBranch.setBoolPref(pref_name, value);
                   break;
                 case prefBranch.PREF_STRING:
-                  prefBranch.setCharPref(pref, value);
+                  prefBranch.setCharPref(pref_name, value);
                   break;
                 case prefBranch.PREF_INT:
-                  prefBranch.setIntPref(pref, value);
+                  prefBranch.setIntPref(pref_name, value);
                   break;
                 default:
                   return false;
               }
 
               return true;
-            """, script_args=[pref, value])
+            """, script_args=[pref_name, value])
 
-        assert ret
-
-    def restore_pref(self, pref):
-        """
-        Restore a previously set pref back to its original value.
-
-        :param pref: The preference to restore. It must be a preference that
-                     was previously set using `set_pref`.
-        """
-        return self.set_pref(pref, self.archive[pref])
+        assert retval

--- a/greenlight/lib/docs/api/prefs.rst
+++ b/greenlight/lib/docs/api/prefs.rst
@@ -3,5 +3,16 @@
 Preferences
 ===========
 
-.. autoclass:: DefaultPrefBranch
+The Preferences class is a wrapper around the nsIPrefBranch_ interface in
+Firefox and allows you to interact with the preferences system. It only
+includes the most commonly used methods of that interface, whereby it also
+enhances the logic in terms of e.g. restoring the original value of modified
+preferences.
+
+.. _nsIPrefBranch: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefBranch
+
+API reference
+-------------
+
+.. autoclass:: Preferences
    :members:

--- a/greenlight/lib/docs/api/windows.rst
+++ b/greenlight/lib/docs/api/windows.rst
@@ -1,4 +1,4 @@
-.. py:currentmodule:: greenlight.lib.windows
+.. py:currentmodule:: greenlight.lib.api.windows
 
 Windows
 =======

--- a/greenlight/lib/docs/index.rst
+++ b/greenlight/lib/docs/index.rst
@@ -38,7 +38,6 @@ future. Each library is available from an instance of the FirefoxTestCase class.
 .. toctree::
    :hidden:
 
-   windows
    ui/base_window
    ui/browser_window
    ui/menu
@@ -47,6 +46,7 @@ future. Each library is available from an instance of the FirefoxTestCase class.
    api/keys
    api/l10n
    api/prefs
+   api/windows
 
 
 Indices and tables

--- a/greenlight/lib/tests/manifest.ini
+++ b/greenlight/lib/tests/manifest.ini
@@ -1,4 +1,5 @@
 [test_l10n.py]
 [test_menubar.py]
+[test_prefs.py]
 [test_tabs.py]
 [test_windows.py]

--- a/greenlight/lib/tests/test_prefs.py
+++ b/greenlight/lib/tests/test_prefs.py
@@ -1,0 +1,156 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette.errors import MarionetteException
+
+from greenlight.harness.testcase import FirefoxTestCase
+
+
+class testPreferences(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.new_pref = 'marionette.unittest.set_pref'
+        self.unknown_pref = 'marionette.unittest.unknown'
+
+        self.bool_pref = 'browser.tabs.loadBookmarksInBackground'
+        self.int_pref = 'browser.tabs.maxOpenBeforeWarn'
+        self.string_pref = 'browser.newtab.url'
+
+    def test_reset_pref(self):
+        self.prefs.set_pref(self.new_pref, 'unittest')
+        self.assertEqual(self.prefs.get_pref(self.new_pref), 'unittest')
+
+        # Preference gets removed
+        self.assertTrue(self.prefs.reset_pref(self.new_pref))
+        self.assertEqual(self.prefs.get_pref(self.new_pref), None)
+
+        # There is no such preference anymore
+        self.assertFalse(self.prefs.reset_pref(self.string_pref))
+
+    def test_get_pref(self):
+        # check correct types
+        self.assertTrue(isinstance(self.prefs.get_pref(self.bool_pref),
+                                   bool))
+        self.assertTrue(isinstance(self.prefs.get_pref(self.int_pref),
+                                   int))
+        self.assertTrue(isinstance(self.prefs.get_pref(self.string_pref),
+                                   basestring))
+
+        # unknown
+        self.assertIsNone(self.prefs.get_pref(self.unknown_pref))
+
+        # default branch
+        orig_value = self.prefs.get_pref(self.int_pref)
+        self.prefs.set_pref(self.int_pref, 99999)
+        self.assertEqual(self.prefs.get_pref(self.int_pref), 99999)
+        self.assertEqual(self.prefs.get_pref(self.int_pref, True), orig_value)
+
+        # complex value
+        properties_file = 'chrome://branding/locale/browserconfig.properties'
+        self.assertEqual(self.prefs.get_pref('browser.startup.homepage'),
+                         properties_file)
+
+        value = self.prefs.get_pref('browser.startup.homepage',
+                                    interface='nsIPrefLocalizedString')
+        self.assertNotEqual(value, properties_file)
+
+    def test_restore_pref(self):
+        # test with single set_pref call and a new preference
+        self.prefs.set_pref(self.new_pref, True)
+        self.assertTrue(self.prefs.get_pref(self.new_pref))
+        self.prefs.restore_pref(self.new_pref)
+
+        orig_value = self.prefs.get_pref(self.string_pref)
+
+        # test with single set_pref call
+        self.prefs.set_pref(self.string_pref, 'unittest')
+        self.assertEqual(self.prefs.get_pref(self.string_pref), 'unittest')
+        self.prefs.restore_pref(self.string_pref)
+        self.assertEqual(self.prefs.get_pref(self.string_pref), orig_value)
+
+        # test with multiple set_pref calls
+        self.prefs.set_pref(self.string_pref, 'unittest1')
+        self.prefs.set_pref(self.string_pref, 'unittest2')
+        self.assertEqual(self.prefs.get_pref(self.string_pref), 'unittest2')
+        self.prefs.restore_pref(self.string_pref)
+        self.assertEqual(self.prefs.get_pref(self.string_pref), orig_value)
+
+        # test with multiple restore_pref calls
+        self.prefs.set_pref(self.string_pref, 'unittest3')
+        self.prefs.restore_pref(self.string_pref)
+        self.assertRaises(MarionetteException,
+                          self.prefs.restore_pref, self.string_pref)
+
+        # test with an unknown pref
+        self.assertRaises(MarionetteException,
+                          self.prefs.restore_pref, self.unknown_pref)
+
+    def test_restore_all_prefs(self):
+        orig_bool = self.prefs.get_pref(self.bool_pref)
+        orig_int = self.prefs.get_pref(self.int_pref)
+        orig_string = self.prefs.get_pref(self.string_pref)
+
+        self.prefs.set_pref(self.bool_pref, not orig_bool)
+        self.prefs.set_pref(self.int_pref, 99999)
+        self.prefs.set_pref(self.string_pref, 'unittest')
+
+        self.prefs.restore_all_prefs()
+        self.assertEqual(self.prefs.get_pref(self.bool_pref), orig_bool)
+        self.assertEqual(self.prefs.get_pref(self.int_pref), orig_int)
+        self.assertEqual(self.prefs.get_pref(self.string_pref), orig_string)
+
+    def test_set_pref_casted_values(self):
+        # basestring as boolean
+        self.prefs.set_pref(self.bool_pref, '')
+        self.assertFalse(self.prefs.get_pref(self.bool_pref))
+
+        self.prefs.set_pref(self.bool_pref, 'unittest')
+        self.assertTrue(self.prefs.get_pref(self.bool_pref))
+
+        # int as boolean
+        self.prefs.set_pref(self.bool_pref, 0)
+        self.assertFalse(self.prefs.get_pref(self.bool_pref))
+
+        self.prefs.set_pref(self.bool_pref, 5)
+        self.assertTrue(self.prefs.get_pref(self.bool_pref))
+
+        # boolean as int
+        self.prefs.set_pref(self.int_pref, False)
+        self.assertEqual(self.prefs.get_pref(self.int_pref), 0)
+
+        self.prefs.set_pref(self.int_pref, True)
+        self.assertEqual(self.prefs.get_pref(self.int_pref), 1)
+
+        # int as string
+        self.prefs.set_pref(self.string_pref, 54)
+        self.assertEqual(self.prefs.get_pref(self.string_pref), '54')
+
+    def test_set_pref_invalid(self):
+        self.assertRaises(AssertionError,
+                          self.prefs.set_pref, self.new_pref, None)
+
+    def test_set_pref_new_preference(self):
+        self.prefs.set_pref(self.new_pref, True)
+        self.assertTrue(self.prefs.get_pref(self.new_pref))
+        self.prefs.restore_pref(self.new_pref)
+
+        self.prefs.set_pref(self.new_pref, 5)
+        self.assertEqual(self.prefs.get_pref(self.new_pref), 5)
+        self.prefs.restore_pref(self.new_pref)
+
+        self.prefs.set_pref(self.new_pref, 'test')
+        self.assertEqual(self.prefs.get_pref(self.new_pref), 'test')
+        self.prefs.restore_pref(self.new_pref)
+
+    def test_set_pref_new_values(self):
+        self.prefs.set_pref(self.bool_pref, True)
+        self.assertTrue(self.prefs.get_pref(self.bool_pref))
+
+        self.prefs.set_pref(self.int_pref, 99999)
+        self.assertEqual(self.prefs.get_pref(self.int_pref), 99999)
+
+        self.prefs.set_pref(self.string_pref, 'test_string')
+        self.assertEqual(self.prefs.get_pref(self.string_pref), 'test_string')


### PR DESCRIPTION
This fixes issue #39. @chmanchester can you please have a look? With all the changes we have everything what we need and are nearly identical with the mozmill prefs module, except for setting complex preferences. Checking our Mozmill tests I actually haven't found any instance so far where this would be necessary. Means I'm happy to not include it right now.